### PR TITLE
Refine typography for a more premium feel

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Playfair+Display+SC:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=Poppins:wght@100&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Playfair+Display+SC:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=Poppins:wght@100&family=Cormorant+Garamond:ital,wght@0,300;0,400;1,300;1,400&display=swap"
       rel="stylesheet" />
     <link
       rel="stylesheet"
@@ -73,6 +73,15 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer" />
     <title>AB Winetrader | Enoteca Vini Pregiati a Collegno, Torino</title>
+    <style>
+      .cormorant-light { font-family: 'Cormorant Garamond', serif; font-weight: 300; font-style: normal; }
+      .tracking-\[0\.05em\] { letter-spacing: 0.05em; }
+      .tracking-\[0\.08em\] { letter-spacing: 0.08em; }
+      .tracking-\[0\.15em\] { letter-spacing: 0.15em; }
+      .leading-\[1\.7\] { line-height: 1.7; }
+      .text-base { font-size: 1rem; line-height: 1.5rem; }
+      @media (min-width: 480px) { .sm\:text-lg { font-size: 1.125rem; line-height: 1.75rem; } }
+    </style>
   </head>
 
   <body>
@@ -86,7 +95,7 @@
             alt="Logo AB Winetrader – Enoteca a Collegno"
             class="h-[35px] w-[12px] mr-2"
             width="278" height="782" />
-          <span class="text-xl text-gray-300 playfair-display-sc-bold"
+          <span class="text-xl text-gray-300 cormorant-light tracking-[0.08em]"
             >ab winetrader
           </span>
         </div>
@@ -138,20 +147,20 @@
         width="278" height="782" loading="lazy" />
       <div class="mt-[140px] px-4 md:px-8 flex flex-col items-center gap-8">
         <h1
-          class="animate__animated animate__fadeInDown playfair-display-sc-black text-white text-[45px] sm:text-[75px] lg:text-[95px] leading-[0.8] text-center tracking-[0.03em] drop-shadow-[0_4px_30px_rgba(87,14,39,0.25)]">
-          <span class="text-white playfair-display-sc-black">AB</span>
+          class="animate__animated animate__fadeInDown cormorant-light text-white text-[45px] sm:text-[75px] lg:text-[95px] leading-[0.8] text-center tracking-[0.05em] drop-shadow-[0_4px_30px_rgba(87,14,39,0.25)]">
+          <span class="text-white cormorant-light">AB</span>
           <br />
           winetrader
         </h1>
         <p
-          class="it-text animate__animated animate__pulse md:w-[600px] text-gray-300 text-center text-sm sm:text-md text-pretty">
+          class="it-text animate__animated animate__pulse md:w-[600px] text-gray-300 text-center text-base sm:text-lg leading-[1.7] text-pretty">
           Commercializziamo bottiglie di pregio ed etichette ricercate. Mettiamo
           a disposizione del cliente grande esperienza nel settore unita alla
           forte passione nel mondo del vino.
         </p>
 
         <p
-          class="en-text hidden md:w-[600px] text-gray-300 text-center text-sm sm:text-md text-pretty">
+          class="en-text hidden md:w-[600px] text-gray-300 text-center text-base sm:text-lg leading-[1.7] text-pretty">
           We market fine bottles and sophisticated labels. We provide to the
           customer great experience in the sector combined with a strong passion
           in the world of wine.
@@ -163,7 +172,7 @@
             href="https://drive.google.com/uc?export=download&id=1hZYQNzIxBpTzQoeFT6Vs8_JgjaG7_RFA"
             download="WineList.pdf">
             <span
-              class="transition-all uppercase duration-[400ms] ease-in-out font-semibold rounded-xl leading-[62px] md:leading-[46px] inline-block text-center w-[320px] md:w-[240px] bg-[#570E27] h-16 md:h-[50px] text-gray-300 cursor-pointer border border-[rgba(255,255,255,0.1)] hover:bg-[#7a1835] hover:text-black hover:border-[rgba(255,255,255,0.2)]">
+              class="transition-all uppercase duration-[400ms] ease-in-out font-semibold rounded-xl leading-[62px] md:leading-[46px] inline-block text-center w-[320px] md:w-[240px] bg-[#570E27] h-16 md:h-[50px] text-gray-300 cursor-pointer border border-[rgba(255,255,255,0.1)] hover:bg-[#7a1835] hover:text-black hover:border-[rgba(255,255,255,0.2)] tracking-[0.15em]">
               Lista dei Vini
             </span>
           </a>
@@ -172,7 +181,7 @@
             download="WineList.pdf"
             class="hidden en-text transition-all duration-[400ms] ease-in-out hover:shadow-[0_14px_30px_-8px_rgba(87,14,39,0.4)]">
             <span
-              class="transition-all uppercase duration-[400ms] ease-in-out font-semibold rounded-xl text-center leading-[62px] md:leading-[46px] inline-block w-[320px] md:w-[240px] bg-[#570E27] h-16 md:h-[50px] text-gray-300 cursor-pointer border border-[rgba(255,255,255,0.1)] hover:bg-[#7a1835] hover:text-black hover:border-[rgba(255,255,255,0.2)]">
+              class="transition-all uppercase duration-[400ms] ease-in-out font-semibold rounded-xl text-center leading-[62px] md:leading-[46px] inline-block w-[320px] md:w-[240px] bg-[#570E27] h-16 md:h-[50px] text-gray-300 cursor-pointer border border-[rgba(255,255,255,0.1)] hover:bg-[#7a1835] hover:text-black hover:border-[rgba(255,255,255,0.2)] tracking-[0.15em]">
               Wine List
             </span>
           </a>
@@ -183,7 +192,7 @@
             rel="noopener noreferrer"
             href="https://wa.me/393355343628">
             <span
-              class="transition-all uppercase duration-[400ms] ease-in-out rounded-xl leading-[62px] md:leading-[46px] inline-block text-center w-[320px] md:w-[240px] bg-blackFooter h-16 md:h-[50px] text-gray-300 cursor-pointer border border-[rgba(255,255,255,0.1)] hover:bg-[#009E91] hover:text-black hover:border-[#009E91]">
+              class="transition-all uppercase duration-[400ms] ease-in-out rounded-xl leading-[62px] md:leading-[46px] inline-block text-center w-[320px] md:w-[240px] bg-blackFooter h-16 md:h-[50px] text-gray-300 cursor-pointer border border-[rgba(255,255,255,0.1)] hover:bg-[#009E91] hover:text-black hover:border-[#009E91] tracking-[0.15em]">
               Whatsapp
             </span>
           </a>


### PR DESCRIPTION
- Hero title: swap Playfair Display SC Black (900) for Cormorant Garamond Light (300) with tighter tracking (0.05em) — less mass, more elegance
- Body copy: increase from text-sm to text-base/sm:text-lg and set line-height 1.7 so the paragraph breathes on mobile
- Buttons: add letter-spacing 0.15em to uppercase labels for a premium spaced look
- Navbar brand: switch to Cormorant Garamond Light with 0.08em tracking so it holds character at small size
- Adds Cormorant Garamond to Google Fonts import and a <style> block for the new utility classes

https://claude.ai/code/session_01YKK5Bfj2VnhVSXX74SVMw9